### PR TITLE
修复部分按键设为 'U8X8_PIN_NONE' 时，其它按键不能正常触发的BUG。

### DIFF
--- a/port/u8g2_port.cpp
+++ b/port/u8g2_port.cpp
@@ -211,34 +211,6 @@ uint8_t u8x8_rt_gpio_and_delay(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void 
             rt_pin_write(u8x8->pins[U8X8_PIN_RESET], arg_int);
             break;
 
-        case U8X8_MSG_GPIO_MENU_SELECT:
-            u8x8_SetGPIOResult(u8x8, 
-                               /* get menu select pin state */ 
-                               rt_pin_read(u8x8->pins[U8X8_PIN_MENU_SELECT]));
-            // rt_kprintf("Menu Select %d\n", rt_pin_read(u8x8->pins[U8X8_PIN_MENU_SELECT]));
-            break;
-
-        case U8X8_MSG_GPIO_MENU_NEXT:
-            u8x8_SetGPIOResult(u8x8, 
-                               /* get menu next pin state */ 
-                               rt_pin_read(u8x8->pins[U8X8_PIN_MENU_NEXT]));
-            // rt_kprintf("Menu Next %d\n", rt_pin_read(u8x8->pins[U8X8_PIN_MENU_NEXT]));
-            break;
-
-        case U8X8_MSG_GPIO_MENU_PREV:
-            u8x8_SetGPIOResult(u8x8, 
-                               /* get menu prev pin state */ 
-                               rt_pin_read(u8x8->pins[U8X8_PIN_MENU_PREV]));
-            // rt_kprintf("Menu Prev %d\n", rt_pin_read(u8x8->pins[U8X8_PIN_MENU_PREV]));
-            break;
-
-        case U8X8_MSG_GPIO_MENU_HOME:
-            u8x8_SetGPIOResult(u8x8, 
-                               /* get menu home pin state */ 
-                               rt_pin_read(u8x8->pins[U8X8_PIN_MENU_HOME]));
-            // rt_kprintf("Menu Home %d\n", rt_pin_read(u8x8->pins[U8X8_PIN_MENU_HOME]));
-            break;
-
         default:
             if ( msg >= U8X8_MSG_GPIO(0) )
             {


### PR DESCRIPTION
假设`U8X8_MSG_GPIO_MENU_HOME`对应的按键定义为`U8X8_PIN_NONE`。
在stm32的BSP中，`rt_pin_read(u8x8->pins[U8X8_PIN_MENU_HOME])`会返回0，所以U8G2会认为该按键按下了。
此外，U8G2的按键检测机制是很简单的，它不支持多个按键同时按下。
因此，由于定义为`U8X8_PIN_NONE`的按键被一直检测到按下，这就导致其它按键的检测失败了。